### PR TITLE
Fetch js file from URL without writing to disk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
 	"name": "dashboar",
-	"version": "1.2.0",
+	"version": "1.2.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "1.2.0",
+			"name": "dashboar",
+			"version": "1.2.3",
 			"license": "MIT",
 			"dependencies": {
 				"bitbucket": "^2.6.3",
@@ -18,6 +19,7 @@
 				"node-fetch": "^2.6.7",
 				"pg": "^8.7.3",
 				"react": "^16.14.0",
+				"require-from-url": "^3.1.3",
 				"simple-git": "^3.7.1",
 				"tunnel-ssh": "^4.1.6"
 			},
@@ -7099,6 +7101,14 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-from-url": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/require-from-url/-/require-from-url-3.1.3.tgz",
+			"integrity": "sha512-SWYVQr6rZMumhsE0MGL3caGtBNDBPQRm7JV4fsxb8Nc+LR42QkmLPP56P+Y9jncZLNrrk4SpE/Ozaf8Jo3ialA==",
+			"engines": {
+				"node": ">=8.11.1"
 			}
 		},
 		"node_modules/reserved-words": {
@@ -14761,6 +14771,11 @@
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"dev": true
+		},
+		"require-from-url": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/require-from-url/-/require-from-url-3.1.3.tgz",
+			"integrity": "sha512-SWYVQr6rZMumhsE0MGL3caGtBNDBPQRm7JV4fsxb8Nc+LR42QkmLPP56P+Y9jncZLNrrk4SpE/Ozaf8Jo3ialA=="
 		},
 		"reserved-words": {
 			"version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"node-fetch": "^2.6.7",
 		"pg": "^8.7.3",
 		"react": "^16.14.0",
+		"require-from-url": "^3.1.3",
 		"simple-git": "^3.7.1",
 		"tunnel-ssh": "^4.1.6"
 	},

--- a/src/lib/getConfigFile.ts
+++ b/src/lib/getConfigFile.ts
@@ -1,20 +1,11 @@
 import { join } from "path";
 import { DashboarConfig } from "./DashboarConfig";
-import fs from "fs";
-const fsPromises = fs.promises;
-
-// using 'import' syntax with node-fetch version 3 causes an error
-// but using 'require' with version 2 works
-const fetch = require("node-fetch");
+const requireFromUrl = require('require-from-url/sync');
 
 const getFileFromUrl = (path: string) => {
     return new Promise<DashboarConfig>(async (resolve, reject) => {
         try {
-            const res = await fetch(path);
-            const responseArrayBuffer = await res.arrayBuffer();
-            const filePath = join(process.cwd(), "./dashboar-config.custom.js");
-            await fsPromises.writeFile(filePath, Buffer.from(responseArrayBuffer));
-            const configFile = require(filePath);
+            const configFile: DashboarConfig = requireFromUrl(path);
             resolve(configFile);
         } catch (error) {
             reject(error);


### PR DESCRIPTION
- installed the `require-from-url` package to fetch remote config files

- could not get  `require-from-url/async` to work but  `require-from-url/sync` works fine